### PR TITLE
Improve READMEs of most example projects

### DIFF
--- a/auth-cognito/README.md
+++ b/auth-cognito/README.md
@@ -1,8 +1,10 @@
 # Authentication with SotoCognitoAuthenticationKit
 
-Example of app using SotoCognitoAuthenticationKit. App includes four authenticators (basic username and password, basic username and password using SRP (Secure Remote Password) for authentication, JWT Access Token and JWT Id Token. This example also uses the result builder router from HummingbirdRouter.
+Example of app using [Soto's](https://github.com/soto-project/soto) SotoCognitoAuthenticationKit. This app includes four authenticators (basic username and password, basic username and password using SRP (Secure Remote Password) for authentication, JWT Access Token and JWT Id Token. This example also uses the result builder router from [HummingbirdRouter](https://docs.hummingbird.codes/2.0/documentation/hummingbirdrouter).
 
-Routes are as follows
+### Routes
+
+The following routes are present in this application.
 
 - PUT /user - Create a new user
 - POST /user/login - Login in user with username and password
@@ -18,4 +20,6 @@ Routes are as follows
 - POST /user/mfa/enable - Enable software MFA for user
 - POST /user/mfa/disable - Disable software MFA for user
 
-This example requires that you setup an AWS Cognito userpool and application client with ADMIN_USER_PASSWORD, REFRESH_TOKEN and USER_SRP authentication methods all enabled. You should then set environment variables `COGNITO_USER_POOL_ID` to the userpool id, `COGNITO_CLIENT_ID` to the application client id and if you added a client secret `COGNITO_CLIENT_SECRET` to that.
+### Running the Example
+
+This example requires that you setup an AWS Cognito userpool and application client with *ADMIN_USER_PASSWORD*, *REFRESH_TOKEN* and *USER_SRP* authentication methods all enabled. You should then set environment variables `COGNITO_USER_POOL_ID` to the userpool id, `COGNITO_CLIENT_ID` to the application client id and if you added a client secret `COGNITO_CLIENT_SECRET` to that.

--- a/auth-jwt/README.md
+++ b/auth-jwt/README.md
@@ -1,10 +1,13 @@
 # Auth Token (JWT)
 
-This shows two ways in which you can use JWTs for authentication. 
+This project shows two ways in which you can use JWTs using [JWTKit](https://github.com/vapor/jwt-kit) for authentication. 
+
 - With `RS256` tokens issues by third party providers. 
 - And generating it's own JWTs after a basic username/password authentication 
 
 For the third party authentication to work you need to supply a URL to the JSON Web Key Store (JWKS).
+
+You can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
 
 ## Usage
 

--- a/auth-jwt/README.md
+++ b/auth-jwt/README.md
@@ -7,8 +7,6 @@ This project shows two ways in which you can use JWTs using [JWTKit](https://git
 
 For the third party authentication to work you need to supply a URL to the JSON Web Key Store (JWKS).
 
-You can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
-
 ## Usage
 
 ### With Third Party Provider

--- a/auth-srp/README.md
+++ b/auth-srp/README.md
@@ -2,9 +2,15 @@
 
 Application demonstrating authentication using Secure Remote Password.
 
+You can run and experiment with the example by building the Dockerfile and running the container.
+
+Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
+
+### What is SRP?
+
 Secure Remote Password (SRP) is a method to authenticate with your server application without ever passing your password to the server. Because the server never knows your password it can never be leaked in an attack on the server. Also because the password is never passed to the server it can not be obtained via an eavesdropper or man in the middle attack.
 
-The authentication works by the client demonstrating to the server they know the password without sending the password. Furthermore the server then has to demonstrate to the client it knows enough about the password, to avoid phishing attacks. More can be found out about SRP [here](https://datatracker.ietf.org/doc/html/rfc2945). Wikipedia also have a detailed description of the method [here](https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol).
+The authentication works by the client demonstrating to the server they know the password without sending the password. Furthermore the server then has to demonstrate to the client it knows enough about the password, to avoid phishing attacks. Learn more about SRP [here](https://datatracker.ietf.org/doc/html/rfc2945). Wikipedia also have a detailed description of the method [here](https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol).
 
 Because this example serves a couple of web pages, you will need to make sure you have set the working directory to the root folder of the example before running. Also the example uses Fluent to store data in a database. The first time you run it you should include the command line argument `--migrate`.
 
@@ -17,7 +23,7 @@ The login process found in `login.html` has a number of stages.
 1) The client creates a random private key, and derived public key. 
 2) The public key is sent to the server along with the username. 
 3) The server looks up the salt and verifier associated with the username.
-4) The server then generates its own public/private key pair and returns its public key, the salt associated with the username and a session key. It will store the data required to finished the authentication in an SRP session object and this is then stored alongside the session key using the [persist](https://github.com/hummingbird-project/hummingbird/blob/main/Sources/Hummingbird/Storage/Application%2BPersist.swift) framework.
+4) The server then generates its own public/private key pair and returns its public key, the salt associated with the username and a session key. It will store the data required to finished the authentication in an SRP session object and this is then stored alongside the session key using the [persistent data](https://docs.hummingbird.codes/2.0/documentation/hummingbird/persistentdata) framework.
 5) The client creates a shared secret from its own public/private key pair, the public server key, the username, password and salt. 
 6) The server is also able to create this shared secret using its own public/private key pair, the public client key and the verifier associated with the username.
 7) At this point the client could send the secret to the server and they could be compared, but instead the client sends a proof (derived from the data both client and server have) that it knows the shared secret, along with the session key so the server can find SRP session data it stored from the previous call.

--- a/auth-srp/README.md
+++ b/auth-srp/README.md
@@ -2,10 +2,6 @@
 
 Application demonstrating authentication using Secure Remote Password.
 
-You can run and experiment with the example by building the Dockerfile and running the container.
-
-Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
-
 ### What is SRP?
 
 Secure Remote Password (SRP) is a method to authenticate with your server application without ever passing your password to the server. Because the server never knows your password it can never be leaked in an attack on the server. Also because the password is never passed to the server it can not be obtained via an eavesdropper or man in the middle attack.

--- a/graphql-server/README.md
+++ b/graphql-server/README.md
@@ -4,10 +4,6 @@
 
 This example uses the GraphQLSwift [Graphiti](https://github.com/GraphQLSwift/Graphiti#getting-started) hosted with Hummingbird as the server framework with the [Graphiti StarWars API example](https://github.com/GraphQLSwift/Graphiti/tree/main/Tests/GraphitiTests).
 
-You can run and experiment with the example by building the Dockerfile and running the container.
-
-Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
-
 ## Ideas to extend use
 
 - Replace the `StarWarsContext` with `Fluent` or another persistance layer

--- a/graphql-server/README.md
+++ b/graphql-server/README.md
@@ -1,6 +1,12 @@
-# GraphQL Server 
+# GraphQL Server
+
+[GraphQL](https://graphql.org/) is a query language for APIs and a runtime for executing those queries by using a type system you define for your data.
 
 This example uses the GraphQLSwift [Graphiti](https://github.com/GraphQLSwift/Graphiti#getting-started) hosted with Hummingbird as the server framework with the [Graphiti StarWars API example](https://github.com/GraphQLSwift/Graphiti/tree/main/Tests/GraphitiTests).
+
+You can run and experiment with the example by building the Dockerfile and running the container.
+
+Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).
 
 ## Ideas to extend use
 

--- a/hello/README.md
+++ b/hello/README.md
@@ -1,9 +1,9 @@
 # Hello
 
-Simple app that will responds with the word "hello". This example is here just to demonstrate how to start up a server.
+This is a simple app that will responds with the word "hello". This example is here just to demonstrate how to start up a server.
 
 You can test the sample as follows
-```
+```sh
 curl localhost:8080/
 ```
 It should return a response with status 200 and the body text "Hello".

--- a/html-form/README.md
+++ b/html-form/README.md
@@ -1,7 +1,11 @@
 # Hummingbird HTML Form
 
-Application demonstrating working with HTML forms. Set the working directory to the local folder, run app and open up a web browser and go to localhost:8080. 
+This application demonstrates working with HTML forms. Set the working directory to the local folder, run app and open up a web browser and go to http://localhost:8080. 
 
-The HTML form is generated using the [HummingbirdMustache](https://github.com/hummingbird-project/hummingbird-mustache) library. A new type `HTML` is added that conforms to `HBResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
+The HTML form is generated using the [Mustache](https://github.com/hummingbird-project/swift-mustache) library. A new type `HTML` is added that conforms to `ResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
 
-Added a new `HBRequestDecoder` that checks the header value `content-type` and if it is `application/x-www-form-urlencoded` then decodes request using `URLEncodedFormDecoder`. Otherwise returns unsupported media type.
+Added a new `RequestDecoder` that checks the header value `content-type` and if it is `application/x-www-form-urlencoded` then decodes request using `URLFormRequestDecoder`. Otherwise returns unsupported media type.
+
+You can run and experiment with the example by building the Dockerfile and running the container.
+
+Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).

--- a/html-form/README.md
+++ b/html-form/README.md
@@ -4,4 +4,4 @@ This application demonstrates working with HTML forms. Set the working directory
 
 The HTML form is generated using the [Mustache](https://github.com/hummingbird-project/swift-mustache) library. A new type `HTML` is added that conforms to `ResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
 
-Added a new `RequestDecoder` that checks the header value `content-type` and if it is `application/x-www-form-urlencoded` then decodes request using `URLFormRequestDecoder`. Otherwise returns unsupported media type.
+Added a new `RequestDecoder` that checks the header value `content-type` and if it is `application/x-www-form-urlencoded` then decodes request using `URLFormRequestDecoder`. Otherwise returns unsupported media type.gp

--- a/html-form/README.md
+++ b/html-form/README.md
@@ -5,7 +5,3 @@ This application demonstrates working with HTML forms. Set the working directory
 The HTML form is generated using the [Mustache](https://github.com/hummingbird-project/swift-mustache) library. A new type `HTML` is added that conforms to `ResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
 
 Added a new `RequestDecoder` that checks the header value `content-type` and if it is `application/x-www-form-urlencoded` then decodes request using `URLFormRequestDecoder`. Otherwise returns unsupported media type.
-
-You can run and experiment with the example by building the Dockerfile and running the container.
-
-Alternatively, you can build and run the example from [VSCode](https://www.swift.org/documentation/articles/getting-started-with-vscode-swift.html) or [Xcode](https://developer.apple.com/xcode/).

--- a/http2/README.md
+++ b/http2/README.md
@@ -4,13 +4,24 @@ Example demonstrating the setup of a HTTP2 upgrade.
 
 The HTTP2 upgrade is done via TLS so for this to work you need to supply valid certificate chain and private key PEM files for your site. The example comes with a script that will generate a CA certificate, server certificate and private key. You can use these to run the example. 
 
-Run `./scripts/generate-certs.sh`. This will create all the require files in a `resources/certs` folder in the root of the example. If running in Xcode set the working directory for your the project to be the root folder.  
+Run `./scripts/generate-certs.sh`. This will create all the require files in a `resources/certs` folder in the root of the example. If running in Xcode set the working directory for your the project to be the root folder.
 
-```
+```sh
 swift run App
 ```
 
 To test the sample you can use `curl`. You need to provide the root trust certificate that the server certificate and key were generated from.
-```
+
+```sh
 curl --cacert resources/certs/ca.crt https://localhost:8081/http
 ```
+
+### Implementation Notes
+
+The most important line needed to enable HTTP2 is the following:
+
+```swift
+server: .http2Upgrade(tlsConfiguration: arguments.tlsConfiguration),
+```
+
+It's located in `Application+build.swift`, and requires a `TLSConfiguration` to be passed in. This configuration is created in `app.swift` .

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,9 +1,11 @@
 # Hello
 
-Simple app demonstrating the HummingbirdJobs job queues
+Simple app demonstrating the [Jobs](https://github.com/hummingbird-project/swift-jobs) framework for job queues.
 
 The app uses redis to store the job queue so you need a copy of redis running
-```swift
+
+```sh
 docker run -p 6379:6379 redis
 ```
+
 This demonstrates an HTTP server writing to a job queue. If another version of the app is running with the command line argument `--process-jobs` it will pick up these jobs and execute them. The example demonstrates how to offload work to another server.

--- a/multipart-form/README.md
+++ b/multipart-form/README.md
@@ -4,4 +4,4 @@ Application demonstrating working with HTML forms using multipart form data. Set
 
 This example uses the [MultipartKit](https://github.com/vapor/multipart-kit) package for decoding the multipart form data sent by the web browser. The HTML form is generated using the [Mustache](https://github.com/hummingbird-project/swift-mustache) library. A new type `HTML` is added that conforms to `ResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
 
-It also adds a new `RequestDecoder` called `MultipartRequestDecoder` that checks the header value `content-type` and if its media type is `.multipartForm` then decodes request using `FormDataDecoder` from the MultipartKit package. Other data will result in the app returning "unsupported media type".
+It also adds a new `RequestDecoder` called `MultipartRequestDecoder` that checks the header value `content-type` and if its media type is `.multipartForm` then decodes request using `FormDataDecoder` from the MultipartKit package. Other content types will result in the app returning "unsupported media type".

--- a/multipart-form/README.md
+++ b/multipart-form/README.md
@@ -4,4 +4,4 @@ Application demonstrating working with HTML forms using multipart form data. Set
 
 This example uses the [MultipartKit](https://github.com/vapor/multipart-kit) package for decoding the multipart form data sent by the web browser. The HTML form is generated using the [Mustache](https://github.com/hummingbird-project/swift-mustache) library. A new type `HTML` is added that conforms to `ResponseGenerator`. This generates a response with the `HTML` text contents and a `content-type` header set to `text/html`.
 
-Added a new `RequestDecoder` that checks the header value `content-type` and if its media type is `.multipartForm` then decodes request using `FormDataDecoder` from the MultipartKit package. Otherwise returns unsupported media type.
+It also adds a new `RequestDecoder` called `MultipartRequestDecoder` that checks the header value `content-type` and if its media type is `.multipartForm` then decodes request using `FormDataDecoder` from the MultipartKit package. Other data will result in the app returning "unsupported media type".

--- a/proxy-server/README.md
+++ b/proxy-server/README.md
@@ -1,9 +1,11 @@
 # Proxy Server
 
-Demonstrating how to use `Hummingbird` and `AsyncHTTPClient` to build a HTTP Proxy server. 
+Demonstrates how to use `Hummingbird` and `AsyncHTTPClient` to build a HTTP Proxy server. 
 
-This is a fairly simple app which forwards HTTP requests to the proxy server onto another server. The forwarding of requests is done by the middleware `HBProxyServerMiddleware`.  
+This is a fairly simple app which forwards HTTP requests to another server. The forwarding of requests is done by the middleware `ProxyServerMiddleware`.  
 
-There is still some complexity in that the server streams the request body and response body to avoid having to allocate large buffers. The response streaming needs a `HTTPClientResponseDelegate` to stream the responses from `AsyncHTTPClient`. Once the delegate has received the HTTP head of the response we succeed a promise to pass back a `HBHTTPResponse` which holds this HTTP head and a `ByteBuffer` streamer. The delegate will continue to feed any `ByteBuffers` it receives to this streamer. Meanwhile Hummingbird server will consume the buffers and pass them back to the original client.
+When the proxy server receives a request it will create a new `HTTPClientRequest` object for the AsyncHTTPClient library, and set the URL to the target server. It will then stream the request body to the target server, ensuring backpressure is respected without significant memory usage.
+
+The HTTP response that is received from the target server is received in a streaming fashion by AsyncHTTPClient, which also supports backpressure. The response is then streamed back to the original client by Hummingbird.
 
 By default the proxy server will send requests to `localhost:8080` so you can run this with most of the other hummingbird samples and use the proxy server address `localhost:8081` to access them. If you want to target a different server add the command line `--target server-address`.

--- a/response-body-processing/README.md
+++ b/response-body-processing/README.md
@@ -2,11 +2,14 @@
 
 This is an example demostrating how you can process Response bodies in middleware using a type conforming to `ResponseBodyWriter`. The server has one endpoint `/echo` which will echo the body of the request back in its response. The response will also include in the response the SHA256 of the data being sent back as a trailing header.
 
-You can test the sample as follows
-```
+You can test the sample as follows:
+
+```sh
 curl localhost:8080/echo -i -d"Hello world"
 ```
-It should response with 
+
+It should respond with:
+
 ```
 HTTP/1.1 200 OK
 Content-Type: application/x-www-form-urlencoded

--- a/todos-auth-fluent/README.md
+++ b/todos-auth-fluent/README.md
@@ -1,7 +1,9 @@
 # Todos and Authentication
 
-This is a more complete example. It is a web interface for editing todos associated with a user. It implements authentication via a login page and session management. User and session details are stored in an SQLite database. Once authenticated you can create todos, list them, edit their completed state and delete them. All the webpages are generated using mustache.
+This is a more complete example, featuring a web page, database and user authentication.
+
+It is a web interface for editing todos associated with a user. It implements authentication via a login page and session management. User and session details are stored in an SQLite database. Once authenticated you can create todos, list them, edit their completed state and delete them. All the webpages are generated using [Mustache](https://github.com/hummingbird-project/swift-mustache).
 
 The first time you run this app you should run it with the `--migrate` command line parameter to ensure the database is setup.
 
-Run the app and open up a web browser and go to localhost:8080. 
+Run the app and open up a web browser and go to http://localhost:8080

--- a/todos-fluent/README.md
+++ b/todos-fluent/README.md
@@ -1,6 +1,6 @@
 # Todos Fluent
 
-This is an implementation of the [TodoBackend](http://www.todobackend.com/) API using an SQLite database accessed via Fluent to store the todo data. The application has six routes
+This is an implementation of the [TodoBackend](http://www.todobackend.com/) API using an SQLite database accessed via the [Fluent](https://github.com/vapor/fluent) ORM to store the TODO data in SQLite. The application has six routes:
 
 - GET /todos: Lists all the todos in the database
 - POST /todos: Creates a new todo

--- a/todos-lambda/README.md
+++ b/todos-lambda/README.md
@@ -1,6 +1,6 @@
 # Todos Lambda
 
-This is an implementation of the [TodoBackend](http://www.todobackend.com/) API using HummingbirdLambda to run on an AWS Lambda. It uses DynamoDB to store the todo data. It has six routes
+This is an implementation of the [TodoBackend](http://www.todobackend.com/) API using [HummingbirdLambda](https://github.com/hummingbird-project/hummingbird-lambda) to run on an [AWS Lambda](https://aws.amazon.com/lambda/). It uses [DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html) to store the todo data. It has six routes
 
 - GET /todos: Lists all the todos in the database
 - POST /todos: Creates a new todo

--- a/todos-mongokitten-openapi/README.md
+++ b/todos-mongokitten-openapi/README.md
@@ -1,6 +1,6 @@
 # Todos MongoKitten OpenAPI
 
-This is an implementation of an API using an OpenAPI specification. The API uses a MongoDB database accessed via MongoKitten to store the todo data.
+This is an implementation of an API using an [OpenAPI](https://swagger.io/resources/open-api/) specification. The API uses a [MongoDB](https://mongodb.com) database accessed via [MongoKitten](https://github.com/orlandos-nl/MongoKitten) to store the todo data.
 
 This API has four routes:
 

--- a/upload-s3/README.md
+++ b/upload-s3/README.md
@@ -1,8 +1,8 @@
 # Example Async/Await File Upload using S3 as backing storage
 
-Demonstrating file uploads to S3 using the async/await APIs of Hummingbird.
+Demonstrating file uploads to S3 using Hummingbird and [Soto](https://github.com/soto-project/soto).
 
-This example requires you have an AWS account with access to S3. You should setup an S3 bucket to save your files to. Before running the application set the "s3_upload_bucket" environment variable to the name of your S3 bucket. You can also use the "s3_upload_folder" environment variable to control what folder inside your S3 bucket the files will be saved to.
+This example requires you have an [AWS](https://aws.amazon.com) account with access to S3. You should setup an S3 bucket to save your files to. Before running the application set the "s3_upload_bucket" environment variable to the name of your S3 bucket. You can also use the "s3_upload_folder" environment variable to control what folder inside your S3 bucket the files will be saved to.
 
 ## Requirements
 

--- a/upload/README.md
+++ b/upload/README.md
@@ -1,6 +1,6 @@
 # Example Async/Await File Upload
 
-Demonstrating file uploads using the async/await APIs of Hummingbird.
+Demonstrating file uploads to disk using Hummingbird.
 
 This demo may be useful for organziations that handle secret / sensitive data or otherwise do not want to rely on third party object storage vendors.
 

--- a/webauthn/README.md
+++ b/webauthn/README.md
@@ -1,5 +1,7 @@
 # WebAuthn
 
-Application demostrating authentication via WebAuthn passkeys. This example uses the webAuthn library https://github.com/swift-server/webauthn-swift. The sample also uses the result builder router `HBRouterBuilder` from HummingbirdRouter
+WebAuthn is a standard for secure authentication on the web. It allows users to authenticate using a hardware token, such as a YubiKey, an iPhone or a biometric device, such as a fingerprint reader. This example demonstrates how to use the [webauthn-swift](https://github.com/swift-server/webauthn-swift) library to authenticate users using WebAuthn.
 
-In your browser go to `localhost:8080`.
+Application demostrating authentication via WebAuthn passkeys. This example uses the webAuthn library https://github.com/swift-server/webauthn-swift. The sample also uses the result builder router from [HummingbirdRouter](https://docs.hummingbird.codes/2.0/documentation/hummingbirdrouter).
+
+In your browser go to http://localhost:8080

--- a/websocket-chat/README.md
+++ b/websocket-chat/README.md
@@ -1,8 +1,10 @@
 # Hummingbird Websocket chat 
 
-Application demonstrating how to use web sockets. 
+Application demonstrating how to use [web sockets](https://github.com/hummingbird-project/hummingbird-websocket) with Hummingbird 2.
 
-Run the application and then using a web browser go to `localhost:8080/chat.html`. Enter a name and start typing messages. Open another web browser page to create a second connection and chat between the two pages.
+Run the application and then using a web browser go to http://localhost:8080/chat.html
+
+Enter a name and start typing messages. Open another web browser page to create a second connection and chat between the two pages.
 
 The app includes a simple connection manager for managing all the websocket connections.
 

--- a/websocket-echo/README.md
+++ b/websocket-echo/README.md
@@ -2,6 +2,8 @@
 
 Application demonstrating how to use web sockets. 
 
-Run the application and then using a web browser go to `localhost:8080/echo.html`. Press connect and start typing messages. It should respond with the same text as you typed. You can send data as either text or binary.
+Run the application and then using a web browser go to https://localhost:8080/echo.html
+
+Press connect and start typing messages. It should respond with the same text as you typed. You can send data as either text or binary. You can use your browser's inspector to see the websocket messages being sent.
 
 Because this sample serves a web page, you will need to make sure you have set the working directory to the root folder of the example before running. 


### PR DESCRIPTION
- Add links for people to read more about the examples
- Remove `.` after links, so that people can more easily copy them
- Fix symbol names where they were using old knowledge