### PR TITLE
Fix the intention of a search path setting and avoid using string in check if file exists

### DIFF
--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -21,14 +21,14 @@ extension UploadModel {
     /// - Returns: the target directory for uploads
     func destinationURL(searchPath: FileManager.SearchPathDirectory = .documentDirectory, allowsOverwrite: Bool = false) throws -> URL {
         let fileURL = try FileManager.default.url(
-			for: searchPath,
+            for: searchPath,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
         ).appendingPathComponent(self.filename)
 
         guard allowsOverwrite == false else { return fileURL }
-		guard (try? fileURL.checkResourceIsReachable()) == false else {
+        guard (try? fileURL.checkResourceIsReachable()) == false else {
             throw HTTPError(.conflict)
         }
         return fileURL

--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -21,7 +21,7 @@ extension UploadModel {
     /// - Returns: the target directory for uploads
     func destinationURL(searchPath: FileManager.SearchPathDirectory = .documentDirectory, allowsOverwrite: Bool = false) throws -> URL {
         let fileURL = try FileManager.default.url(
-            for: .documentDirectory,
+			for: searchPath,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true

--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -28,7 +28,7 @@ extension UploadModel {
         ).appendingPathComponent(self.filename)
 
         guard allowsOverwrite == false else { return fileURL }
-        guard FileManager.default.fileExists(atPath: fileURL.path) == false else {
+		guard (try? fileURL.checkResourceIsReachable()) == false else {
             throw HTTPError(.conflict)
         }
         return fileURL


### PR DESCRIPTION
Just caught a small bug in an example as well as providing a better api call for url existence.