### PR TITLE
todos-auth-fluent build

### DIFF
--- a/todos-auth-fluent/Package.swift
+++ b/todos-auth-fluent/Package.swift
@@ -8,11 +8,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-auth.git", from: "2.0.0-rc.2"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-fluent.git", from: "2.0.0-beta.2"),
-        .package(url: "https://github.com/hummingbird-project/swift-mustache.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-auth.git", from: "2.0.0-rc.4"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-fluent.git", from: "2.0.0-beta.4"),
+        .package(url: "https://github.com/hummingbird-project/swift-mustache.git", from: "2.0.0-rc.1"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.5"),
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
     ],
     targets: [

--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -21,14 +21,14 @@ extension UploadModel {
     /// - Returns: the target directory for uploads
     func destinationURL(searchPath: FileManager.SearchPathDirectory = .documentDirectory, allowsOverwrite: Bool = false) throws -> URL {
         let fileURL = try FileManager.default.url(
-			for: searchPath,
+            for: searchPath,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
         ).appendingPathComponent(self.filename)
 
         guard allowsOverwrite == false else { return fileURL }
-		guard (try? fileURL.checkResourceIsReachable()) == false else {
+        guard (try? fileURL.checkResourceIsReachable()) == false else {
             throw HTTPError(.conflict)
         }
         return fileURL

--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -21,7 +21,7 @@ extension UploadModel {
     /// - Returns: the target directory for uploads
     func destinationURL(searchPath: FileManager.SearchPathDirectory = .documentDirectory, allowsOverwrite: Bool = false) throws -> URL {
         let fileURL = try FileManager.default.url(
-            for: .documentDirectory,
+			for: searchPath,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true

--- a/upload/Sources/App/Models/UploadModel.swift
+++ b/upload/Sources/App/Models/UploadModel.swift
@@ -28,7 +28,7 @@ extension UploadModel {
         ).appendingPathComponent(self.filename)
 
         guard allowsOverwrite == false else { return fileURL }
-        guard FileManager.default.fileExists(atPath: fileURL.path) == false else {
+		guard (try? fileURL.checkResourceIsReachable()) == false else {
             throw HTTPError(.conflict)
         }
         return fileURL


### PR DESCRIPTION
I blindly updated some of the dependency requirements and the `todos-auth-fluent` example now builds.

I'm still unable to get it to run because of an assert looking for a file in the working directory (which I THINK I changed according to directions, but I'm still investigating), but it builds!