### PR TITLE
Fix Lambda compilation under the Swift 6.0 compiler

### DIFF
--- a/todos-lambda/Sources/App/lambda.swift
+++ b/todos-lambda/Sources/App/lambda.swift
@@ -21,6 +21,8 @@ import SotoDynamoDB
 
 @main
 struct AppLambda: APIGatewayLambdaFunction {
+    typealias Context = BasicLambdaRequestContext<APIGatewayRequest>
+    
     let awsClient: AWSClient
     let logger: Logger
 


### PR DESCRIPTION
Fixes #125 . I tried to see if it's to do with the Swift 6 language mode, but this was not the case. @adam-fowler do you know what the issue might be?