### PR TITLE
Use order-preserving JSON encoder in graphql-server

### DIFF
--- a/graphql-server/Sources/App/GraphQL/GraphQL+HBResponseGenerator.swift
+++ b/graphql-server/Sources/App/GraphQL/GraphQL+HBResponseGenerator.swift
@@ -1,5 +1,0 @@
-import Foundation
-import GraphQL
-import Hummingbird
-
-extension GraphQLResult: ResponseEncodable {}

--- a/graphql-server/Sources/App/GraphQL/GraphQL+ResponseGenerator.swift
+++ b/graphql-server/Sources/App/GraphQL/GraphQL+ResponseGenerator.swift
@@ -1,0 +1,18 @@
+import GraphQL
+import HTTPTypes
+import Hummingbird
+
+extension GraphQLResult: ResponseGenerator {
+    public func response(from _: Request, context _: some RequestContext) throws -> Response {
+        let encoder = GraphQLJSONEncoder()
+        let data = try encoder.encode(self)
+        return Response(
+            status: .ok,
+            headers: [
+                .contentType: "application/json; charset=utf-8",
+                .contentLength: "\(data.count)",
+            ],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+}

--- a/graphql-server/Sources/App/GraphQL/GraphQLError+HTTPResponseError.swift
+++ b/graphql-server/Sources/App/GraphQL/GraphQLError+HTTPResponseError.swift
@@ -2,7 +2,7 @@ import GraphQL
 import HTTPTypes
 import Hummingbird
 
-extension GraphQLError: HTTPResponseError {
+extension GraphQLError {
     /// Simple test to determine if GraphQLError is something that the client can address.
     private var isRequestError: Bool {
         message.starts(with: "Syntax Error") ? true : false
@@ -22,3 +22,9 @@ extension GraphQLError: HTTPResponseError {
         .init(status: self.status, headers: self.headers, body: .init(byteBuffer: ByteBuffer(string: message)))
     }
 }
+
+#if hasFeature(RetroactiveAttribute)
+extension GraphQLError: @retroactive HTTPResponseError {}
+#else
+extension GraphQLError: HTTPResponseError {}
+#endif

--- a/graphql-server/Sources/App/GraphQL/GraphQLError+HTTPResponseError.swift
+++ b/graphql-server/Sources/App/GraphQL/GraphQLError+HTTPResponseError.swift
@@ -19,6 +19,6 @@ extension GraphQLError: HTTPResponseError {
     }
 
     public func response(from request: Request, context: some RequestContext) -> Response {
-        .init(status: status, headers: headers, body: .init(byteBuffer: ByteBuffer(string: message)))
+        .init(status: self.status, headers: self.headers, body: .init(byteBuffer: ByteBuffer(string: message)))
     }
 }

--- a/graphql-server/Sources/App/GraphQL/GraphQLResult+ResponseGenerator.swift
+++ b/graphql-server/Sources/App/GraphQL/GraphQLResult+ResponseGenerator.swift
@@ -2,7 +2,7 @@ import GraphQL
 import HTTPTypes
 import Hummingbird
 
-extension GraphQLResult: ResponseGenerator {
+extension GraphQLResult {
     public func response(from _: Request, context _: some RequestContext) throws -> Response {
         let encoder = GraphQLJSONEncoder()
         let data = try encoder.encode(self)
@@ -16,3 +16,9 @@ extension GraphQLResult: ResponseGenerator {
         )
     }
 }
+
+#if hasFeature(RetroactiveAttribute)
+extension GraphQLResult: @retroactive ResponseGenerator {}
+#else
+extension GraphQLResult: ResponseGenerator {}
+#endif


### PR DESCRIPTION
This uses the GraphQLJSONEncoder when converting a GraphQLResult to a Response to return the query results in the order that the were specified in the request.