### PR TITLE
Add comment about CORS in todos-lambda

### DIFF
--- a/todos-lambda/Sources/App/lambda.swift
+++ b/todos-lambda/Sources/App/lambda.swift
@@ -44,11 +44,16 @@ struct AppLambda: APIGatewayLambdaFunction {
         router.get("/") { _, _ in
             return "Hello"
         }
+
+        // When enabling Lambda function URLs, CORS can be configured at the AWS level, and there's
+        // no need for this middleware.
+        // If you prefer to manage CORS internally instead, use this:
         router.add(middleware: CORSMiddleware(
             allowOrigin: .originBased,
             allowHeaders: [.contentType],
             allowMethods: [.get, .options, .post, .delete, .patch]
         ))
+
         TodoController(dynamoDB: dynamoDB, tableName: tableName).addRoutes(to: router.group("todos"))
 
         return router.buildResponder()


### PR DESCRIPTION
While testing something with a lambda, I noticed I had twice the `Access-Control-Allow-Origin` header, and it led to CORS errors when calling my lambda function from the browser.

Upon investigation, I found that it was due to CORS being set both at the code level, and at the Lambda function URL configuration level. When it's configured in the Lambda URL, there's no need to setup `CORSMiddleware`.

This PR adds a comment about it in the **todos-lambda** sample project.