### PR TITLE
OpenTelemetry example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Examples converted to Hummingbird 2.0
 - [http2](https://github.com/hummingbird-project/hummingbird-examples/tree/main/http2) - Basic application with HTTP2 upgrade added.
 - [jobs](https://github.com/hummingbird-project/hummingbird-examples/tree/main/jobs) - Demonstrating offloading of jobs to another server.
 - [multipart-form](https://github.com/hummingbird-project/hummingbird-examples/tree/main/multipart-form) - HTML form using Multipart form data, using MultipartKit
+- [open-telemetry](https://github.com/hummingbird-project/hummingbird-examples/tree/main/open-telemetry) - Integration with Open Telemetry
 - [proxy-server](https://github.com/hummingbird-project/hummingbird-examples/tree/main/proxy-server) - Using AsyncHTTPClient to build a proxy server
 - [response-body-processing](https://github.com/hummingbird-project/hummingbird-examples/tree/main/response-body-processing) - Example showing how to process a response body in middleware.
 - [s3-file-provider](https://github.com/hummingbird-project/hummingbird-examples/tree/main/s3-file-provider) - Use a custom FileProvider to serve files from S3 with FileMiddleware.

--- a/open-telemetry/.dockerignore
+++ b/open-telemetry/.dockerignore
@@ -1,0 +1,2 @@
+.build
+.git

--- a/open-telemetry/.gitignore
+++ b/open-telemetry/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+/.build
+/.swiftpm
+/.devContainer
+/Packages
+/*.xcodeproj
+xcuserdata/
+/.vscode/*
+!/.vscode/hummingbird.code-snippets
+.env.*
+.env
+/data/

--- a/open-telemetry/Dockerfile
+++ b/open-telemetry/Dockerfile
@@ -1,0 +1,86 @@
+# ================================
+# Build image
+# ================================
+FROM swift:6.0-noble as build
+
+# Install OS updates
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get install -y libjemalloc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up a build area
+WORKDIR /build
+
+# First just resolve dependencies.
+# This creates a cached layer that can be reused
+# as long as your Package.swift/Package.resolved
+# files do not change.
+COPY ./Package.* ./
+RUN swift package resolve
+
+# Copy entire repo into container
+COPY . .
+
+# Build everything, with optimizations, with static linking, and using jemalloc
+RUN swift build -c release \
+    --static-swift-stdlib \
+    -Xlinker -ljemalloc
+
+# Switch to the staging area
+WORKDIR /staging
+
+# Copy main executable to staging area
+RUN cp "$(swift build --package-path /build -c release --show-bin-path)/App" ./
+
+# Copy static swift backtracer binary to staging area
+RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
+
+# Copy resources bundled by SPM to staging area
+RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
+
+# Copy any resouces from the public directory and views directory if the directories exist
+# Ensure that by default, neither the directory nor any of its contents are writable.
+RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
+
+# ================================
+# Run image
+# ================================
+FROM ubuntu:noble
+
+# Make sure all system packages are up to date, and install only essential packages.
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get -q install -y \
+      libjemalloc2 \
+      ca-certificates \
+      tzdata \
+# If your app or its dependencies import FoundationNetworking, also install `libcurl4`.
+      # libcurl4 \
+# If your app or its dependencies import FoundationXML, also install `libxml2`.
+      # libxml2 \
+    && rm -r /var/lib/apt/lists/*
+
+# Create a hummingbird user and group with /app as its home directory
+RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /app hummingbird
+
+# Switch to the new home directory
+WORKDIR /app
+
+# Copy built executable and any staged resources from builder
+COPY --from=build --chown=hummingbird:hummingbird /staging /app
+
+# Provide configuration needed by the built-in crash reporter and some sensible default behaviors.
+ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
+
+# Ensure all further commands run as the hummingbird user
+USER hummingbird:hummingbird
+
+# Let Docker bind to port 8080
+EXPOSE 8080
+
+# Start the Hummingbird service when the image is run, default to listening on 8080 in production environment
+ENTRYPOINT ["./App"]
+CMD ["--hostname", "0.0.0.0", "--port", "8080"]

--- a/open-telemetry/LICENSE
+++ b/open-telemetry/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Adam Fowler
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/open-telemetry/Package.swift
+++ b/open-telemetry/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "open-telemetry",
+    platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
+    products: [
+        .executable(name: "App", targets: ["App"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "0.10.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "OTel", package: "swift-otel"),
+                .product(name: "OTLPGRPC", package: "swift-otel"),
+            ],
+            path: "Sources/App"
+        ),
+        .testTarget(
+            name: "AppTests",
+            dependencies: [
+                .byName(name: "App"),
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
+            ],
+            path: "Tests/AppTests"
+        ),
+    ]
+)

--- a/open-telemetry/Package.swift
+++ b/open-telemetry/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .executable(name: "App", targets: ["App"])
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.6.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/swift-otel/swift-otel.git", .upToNextMinor(from: "0.10.0")),
     ],

--- a/open-telemetry/Package.swift
+++ b/open-telemetry/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "0.10.0"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", .upToNextMinor(from: "0.10.0")),
     ],
     targets: [
         .executableTarget(

--- a/open-telemetry/README.md
+++ b/open-telemetry/README.md
@@ -1,3 +1,3 @@
 # Open Telemetry
 
-Integrate with Open Telemetry using [swift-otel](https://github.com/swift-otel/swift-otel).
+Integrate with OpenTelemetry using [swift-otel](https://github.com/swift-otel/swift-otel).

--- a/open-telemetry/README.md
+++ b/open-telemetry/README.md
@@ -1,0 +1,3 @@
+# Open Telemetry
+
+Integrate with Open Telemetry using [swift-otel](https://github.com/swift-otel/swift-otel).

--- a/open-telemetry/README.md
+++ b/open-telemetry/README.md
@@ -22,4 +22,4 @@ Everything is stored in shared volumes so data will persist between docker compo
 
 ### Grafana
 
-There is also a Grafana service included that will take results from both the Prometheus and Jaeger services. The Grafana endpoint is `http://localhost:3000` When stating up Grafana it will ask for a username and password. You can use `admin` for both.
+There is also a Grafana service included that will take results from both the Prometheus and Jaeger services. The Grafana endpoint is `http://localhost:3000`. When stating up Grafana it will ask for a username and password. You can use `admin` for both.

--- a/open-telemetry/README.md
+++ b/open-telemetry/README.md
@@ -22,4 +22,4 @@ Everything is stored in shared volumes so data will persist between docker compo
 
 ### Grafana
 
-There is also a Grafana service included that will take results from both the Prometheus and Jaeger services. The Grafana endpoint is `http://localhost:3000`. When stating up Grafana it will ask for a username and password. You can use `admin` for both.
+The docker compose file also includes a Grafana service that can be used to visualize the results from both the Prometheus and Jaeger services. The Grafana endpoint is `http://localhost:3000`. When starting up Grafana it will ask for a username and password. You can use `admin` for both.

--- a/open-telemetry/README.md
+++ b/open-telemetry/README.md
@@ -1,3 +1,25 @@
-# Open Telemetry
+# OpenTelemetry
 
 Integrate with OpenTelemetry using [swift-otel](https://github.com/swift-otel/swift-otel).
+
+## Server App
+
+The example has three routes to test
+
+- GET / : returns "Hello!"
+- GET /test/{param} : returns text including {param}
+- POST /wait?time=value : Add a child span and wait for period defined by time query parameter
+
+## Docker compose
+
+The example also comes with a docker-compose file that starts up an OTel collector to collect metrics and traces from the application. This is then forwarded onto Prometheus and Jager instances. You can view the metrics from the Prometheus endpoint `http://localhost:9090`. You can view the traces from the Jaeger endpoint `http://loaclhost:16686`. You can start all of these using
+
+```
+docker compose up
+```
+
+Everything is stored in shared volumes so data will persist between docker compose sessions.
+
+### Grafana
+
+There is also a Grafana service included that will take results from both the Prometheus and Jaeger services. The Grafana endpoint is `http://localhost:3000` When stating up Grafana it will ask for a username and password. You can use `admin` for both.

--- a/open-telemetry/Sources/App/App.swift
+++ b/open-telemetry/Sources/App/App.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import Hummingbird
+import Logging
+
+@main
+struct AppCommand: AsyncParsableCommand, AppArguments {
+    @Option(name: .shortAndLong)
+    var hostname: String = "127.0.0.1"
+
+    @Option(name: .shortAndLong)
+    var port: Int = 8080
+
+    @Option(name: .shortAndLong)
+    var logLevel: Logger.Level?
+
+    func run() async throws {
+        let app = try await buildApplication(self)
+        try await app.runService()
+    }
+}
+
+/// Extend `Logger.Level` so it can be used as an argument
+#if hasFeature(RetroactiveAttribute)
+    extension Logger.Level: @retroactive ExpressibleByArgument {}
+#else
+    extension Logger.Level: ExpressibleByArgument {}
+#endif

--- a/open-telemetry/Sources/App/Application+build.swift
+++ b/open-telemetry/Sources/App/Application+build.swift
@@ -1,0 +1,126 @@
+import Hummingbird
+import Instrumentation
+import Logging
+import Metrics
+import OTLPGRPC
+import OTel
+import ServiceLifecycle
+
+/// Application arguments protocol. We use a protocol so we can call
+/// `buildApplication` inside Tests as well as in the App executable.
+/// Any variables added here also have to be added to `App` in App.swift and
+/// `TestArguments` in AppTest.swift
+public protocol AppArguments {
+    var hostname: String { get }
+    var port: Int { get }
+    var logLevel: Logger.Level? { get }
+}
+
+// Request context used by application
+typealias AppRequestContext = BasicRequestContext
+
+///  Build application
+/// - Parameter arguments: application arguments
+public func buildApplication(_ arguments: some AppArguments) async throws -> some ApplicationProtocol {
+    let environment = Environment()
+    let logger = {
+        var logger = Logger(label: "open-telemetry")
+        logger.logLevel =
+            arguments.logLevel ?? environment.get("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .info
+        return logger
+    }()
+
+    let otel = try await setupOTEL()
+
+    let router = buildRouter()
+    var app = Application(
+        router: router,
+        configuration: .init(
+            address: .hostname(arguments.hostname, port: arguments.port),
+            serverName: "open-telemetry-server"
+        ),
+        logger: logger
+    )
+    app.addServices(otel.metrics, otel.tracer)
+    return app
+}
+
+func setupOTEL() async throws -> (metrics: Service, tracer: Service) {
+    struct EmptyService: Service {
+        func run() async throws {
+            try await gracefulShutdown()
+        }
+    }
+    // Bootstrap the logging backend with the OTel metadata provider which includes span IDs in logging messages.
+    LoggingSystem.bootstrap { label in
+        var handler = StreamLogHandler.standardError(label: label, metadataProvider: .otel)
+        handler.logLevel = .trace
+        return handler
+    }
+    // Configure OTel resource detection to automatically apply helpful attributes to events.
+    let environment = OTelEnvironment.detected()
+    let resourceDetection = OTelResourceDetection(detectors: [
+        OTelProcessResourceDetector(),
+        OTelEnvironmentResourceDetector(environment: environment),
+        .manual(OTelResource(attributes: ["service.name": "hummingbird_server"])),
+    ])
+    let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
+
+    // Bootstrap the metrics backend to export metrics periodically in OTLP/gRPC.
+    let registry = OTelMetricRegistry()
+    let metricsExporter = try OTLPGRPCMetricExporter(configuration: .init(environment: environment))
+    let metrics = OTelPeriodicExportingMetricsReader(
+        resource: resource,
+        producer: registry,
+        exporter: metricsExporter,
+        configuration: .init(
+            environment: environment,
+            exportInterval: .seconds(5)  // NOTE: This is overridden for the example; the default is 60 seconds.
+        )
+    )
+    MetricsSystem.bootstrap(OTLPMetricsFactory(registry: registry))
+
+    // Bootstrap the tracing backend to export traces periodically in OTLP/gRPC.
+    let exporter = try OTLPGRPCSpanExporter(configuration: .init(environment: environment))
+    let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
+    let tracer = OTelTracer(
+        idGenerator: OTelRandomIDGenerator(),
+        sampler: OTelConstantSampler(isOn: true),
+        propagator: OTelW3CPropagator(),
+        processor: processor,
+        environment: environment,
+        resource: resource
+    )
+    InstrumentationSystem.bootstrap(tracer)
+    return (metrics: metrics, tracer: tracer)
+}
+
+/// Build router
+func buildRouter() -> Router<AppRequestContext> {
+    let router = Router(context: AppRequestContext.self)
+    // Add middleware
+    router.addMiddleware {
+        // logging middleware
+        LogRequestsMiddleware(.info)
+        // metrics middleware
+        MetricsMiddleware()
+        // tracing middleware
+        TracingMiddleware()
+    }
+    // Add default endpoint
+    router.get("/") { _, _ in
+        "Hello!"
+    }
+    // Add test parameter endpoint
+    router.get("/test/{param}") { _, context in
+        let param = try context.parameters.require("param")
+        return "Testing \(param)!"
+    }
+    // Add wait endpoint
+    router.post("/wait") { request, _ in
+        let time = try request.uri.queryParameters.require("time", as: Double.self)
+        try await Task.sleep(for: .seconds(time))
+        return HTTPResponse.Status.ok
+    }
+    return router
+}

--- a/open-telemetry/Sources/App/Application+build.swift
+++ b/open-telemetry/Sources/App/Application+build.swift
@@ -46,11 +46,6 @@ public func buildApplication(_ arguments: some AppArguments) async throws -> som
 }
 
 func setupOTEL() async throws -> (metrics: Service, tracer: Service) {
-    struct EmptyService: Service {
-        func run() async throws {
-            try await gracefulShutdown()
-        }
-    }
     // Bootstrap the logging backend with the OTel metadata provider which includes span IDs in logging messages.
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardError(label: label, metadataProvider: .otel)

--- a/open-telemetry/Sources/App/Application+build.swift
+++ b/open-telemetry/Sources/App/Application+build.swift
@@ -1,11 +1,11 @@
 import Hummingbird
-import Instrumentation
 import Logging
 import Metrics
 import NIOCore
 import OTLPGRPC
 import OTel
 import ServiceLifecycle
+import Tracing
 
 /// Application arguments protocol. We use a protocol so we can call
 /// `buildApplication` inside Tests as well as in the App executable.
@@ -127,7 +127,7 @@ func buildRouter() -> Router<AppRequestContext> {
     router.post("/wait") { request, _ in
         let time = try request.uri.queryParameters.require("time", as: Double.self)
         // Add child span
-        try await InstrumentationSystem.tracer.withSpan("sleep") { span in
+        try await withSpan("sleep") { span in
             span.attributes["wait.time"] = time
             try await Task.sleep(for: .seconds(time))
         }

--- a/open-telemetry/Sources/App/Application+build.swift
+++ b/open-telemetry/Sources/App/Application+build.swift
@@ -112,7 +112,7 @@ func buildRouter() -> Router<AppRequestContext> {
         // tracing middleware
         TracingMiddleware()
         // logging middleware
-        LogRequestsMiddleware(.info)
+        LogRequestsMiddleware(.debug)
     }
     // Add default endpoint
     router.get("/") { _, _ in
@@ -127,7 +127,8 @@ func buildRouter() -> Router<AppRequestContext> {
     router.post("/wait") { request, _ in
         let time = try request.uri.queryParameters.require("time", as: Double.self)
         // Add child span
-        try await InstrumentationSystem.tracer.withSpan("sleep") { _ in
+        try await InstrumentationSystem.tracer.withSpan("sleep") { span in
+            span.attributes["wait.time"] = time
             try await Task.sleep(for: .seconds(time))
         }
         return HTTPResponse.Status.ok

--- a/open-telemetry/Sources/App/Application+build.swift
+++ b/open-telemetry/Sources/App/Application+build.swift
@@ -111,7 +111,10 @@ func buildRouter() -> Router<AppRequestContext> {
     // Add wait endpoint
     router.post("/wait") { request, _ in
         let time = try request.uri.queryParameters.require("time", as: Double.self)
-        try await Task.sleep(for: .seconds(time))
+        // Add child span
+        try await InstrumentationSystem.tracer.withSpan("sleep") { _ in
+            try await Task.sleep(for: .seconds(time))
+        }
         return HTTPResponse.Status.ok
     }
     return router

--- a/open-telemetry/Tests/AppTests/AppTests.swift
+++ b/open-telemetry/Tests/AppTests/AppTests.swift
@@ -1,0 +1,24 @@
+import Hummingbird
+import HummingbirdTesting
+import Logging
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+    struct TestArguments: AppArguments {
+        let hostname = "127.0.0.1"
+        let port = 0
+        let logLevel: Logger.Level? = .trace
+    }
+
+    func testApp() async throws {
+        let args = TestArguments()
+        let app = try await buildApplication(args)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                XCTAssertEqual(response.body, ByteBuffer(string: "Hello!"))
+            }
+        }
+    }
+}

--- a/open-telemetry/config/grafana.yml
+++ b/open-telemetry/config/grafana.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: false
+  - name: Jaeger
+    type: jaeger
+    url: http://jaeger:16686
+    access: proxy
+    isDefault: false

--- a/open-telemetry/config/otel-collector-config.yml
+++ b/open-telemetry/config/otel-collector-config.yml
@@ -1,0 +1,25 @@
+# Receive metrics on :4317
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: otel-collector:4317
+
+exporters:
+  prometheus:
+    endpoint: otel-collector:7070
+    const_labels:
+      collector: "otel-collector"
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger]

--- a/open-telemetry/config/prometheus.yml
+++ b/open-telemetry/config/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: 'api'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["otel-collector:7070"]

--- a/open-telemetry/docker-compose.yml
+++ b/open-telemetry/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.3"
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    depends_on:
+      - jaeger
+    command: ["--config=/etc/otel-collector-config.yml"]
+    ports:
+      - "7070:7070"
+      - "4317:4317"
+    volumes:
+      - "./config/otel-collector-config.yml:/etc/otel-collector-config.yml"
+    
+  prometheus:
+    image: prom/prometheus
+    depends_on:
+      - otel-collector
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./data/prometheus:/prometheus
+
+  jaeger:
+    # Jaeger is one of many options we can choose from as our distributed tracing backend.
+    # It supports OTLP out of the box so it's very easy to get started.
+    # https://www.jaegertracing.io
+    image: jaegertracing/all-in-one
+    ports:
+      - "4317"
+      - "16686:16686" # This is Jaeger's Web UI, visualizing recorded traces
+    volumes:
+      - "./data/jaeger:/badger"
+    environment:
+      - SPAN_STORAGE_TYPE=badger # Use local storage
+      - BADGER_EPHEMERAL=false  # Don't use ephemeral storage
+      - BADGER_DIRECTORY_VALUE=/badger/data
+      - BADGER_DIRECTORY_KEY=/badger/key
+  
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+      - jaeger
+    ports:
+      - "3000:3000" # Grafana UI
+    volumes:
+      - ./config/grafana.yml:/etc/grafana/provisioning/datasources/grafana.yml
+      - ./data/grafana:/var/lib/grafana
+    environment:
+      - GF_PATHS_DATA=/var/lib/grafana


### PR DESCRIPTION
Sets up application with exporting metrics and traces to OpenTelemetry 
Includes docker-compose that sets up otel-collector, Prometheus, Jaeger and Grafana