### PR TITLE
Use SubscriptionID instead of UUID for the subscription map

### DIFF
--- a/server-sent-events/Sources/App/Publisher.swift
+++ b/server-sent-events/Sources/App/Publisher.swift
@@ -62,5 +62,5 @@ actor Publisher<Value: Sendable>: Service {
         self.subscriptions[id] = nil
     }
 
-    var subscriptions: [UUID: AsyncStream<Value>.Continuation]
+    var subscriptions: [SubscriptionID: AsyncStream<Value>.Continuation]
 }


### PR DESCRIPTION
They're technically the same, but for clarity