### PR TITLE
Fix compilation error for auth-opt example.

### DIFF
--- a/auth-otp/Package.swift
+++ b/auth-otp/Package.swift
@@ -28,7 +28,6 @@ let package = Package(
                 .product(name: "HummingbirdOTP", package: "hummingbird-auth"),
                 .product(name: "Mustache", package: "swift-mustache"),
                 .product(name: "HummingbirdPostgres", package: "hummingbird-postgres"),
-                .product(name: "PostgresMigrations", package: "hummingbird-postgres"),
             ],
             path: "Sources/App",
             resources: [.process("Resources")]


### PR DESCRIPTION
When building the `auth-opt` example, I get the following error. 

```console
error: 'auth-otp': product 'PostgresMigrations' required by package 'auth-otp' target 'App' not found in package 'hummingbird-postgres'. Did you mean 'PostgresMigrations'?
```

This PR removes the PostgresMigrations product as it is already being imported from `HummingbirdPostgres`.