### PR TITLE
docs: fix typo in `resources` in every single Dockerfile

### DIFF
--- a/auth-jwe/Dockerfile
+++ b/auth-jwe/Dockerfile
@@ -41,7 +41,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/auth-otp/Dockerfile
+++ b/auth-otp/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/auth-srp/Dockerfile
+++ b/auth-srp/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/graphql-server/Dockerfile
+++ b/graphql-server/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -41,7 +41,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/html-form/Dockerfile
+++ b/html-form/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory if the directories exist
+# Copy any resources from the public directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/http2/Dockerfile
+++ b/http2/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/multipart-form/Dockerfile
+++ b/multipart-form/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory if the directories exist
+# Copy any resources from the public directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/open-telemetry/Dockerfile
+++ b/open-telemetry/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/response-body-processing/Dockerfile
+++ b/response-body-processing/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/s3-file-provider/Dockerfile
+++ b/s3-file-provider/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/server-sent-events/Dockerfile
+++ b/server-sent-events/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/sessions/Dockerfile
+++ b/sessions/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/todos-auth-fluent/Dockerfile
+++ b/todos-auth-fluent/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory if the directories exist
+# Copy any resources from the public directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/todos-postgres-tutorial/Dockerfile
+++ b/todos-postgres-tutorial/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/upload/Dockerfile
+++ b/upload/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/webauthn/Dockerfile
+++ b/webauthn/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory if the directories exist
+# Copy any resources from the public directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/websocket-chat/Dockerfile
+++ b/websocket-chat/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 

--- a/websocket-echo/Dockerfile
+++ b/websocket-echo/Dockerfile
@@ -40,7 +40,7 @@ RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
 
-# Copy any resouces from the public directory and views directory if the directories exist
+# Copy any resources from the public directory and views directory if the directories exist
 # Ensure that by default, neither the directory nor any of its contents are writable.
 RUN [ -d /build/public ] && { mv /build/public ./public && chmod -R a-w ./public; } || true
 


### PR DESCRIPTION
It was kind of funny, but `resources` spelled wrong in every single Dockerfile :)

All changes were comments so fully backward compatible.