### PR TITLE
docs: fix typos of all readme files

### DIFF
--- a/graphql-server/README.md
+++ b/graphql-server/README.md
@@ -6,4 +6,4 @@ This example uses the GraphQLSwift [Graphiti](https://github.com/GraphQLSwift/Gr
 
 ## Ideas to extend use
 
-- Replace the `StarWarsContext` with `Fluent` or another persistance layer
+- Replace the `StarWarsContext` with `Fluent` or another persistence layer

--- a/response-body-processing/README.md
+++ b/response-body-processing/README.md
@@ -1,6 +1,6 @@
 # Echo with SHA256 Digest using ResponseBodyWriter
 
-This is an example demostrating how you can process Response bodies in middleware using a type conforming to `ResponseBodyWriter`. The server has one endpoint `/echo` which will echo the body of the request back in its response. The response will also include in the response the SHA256 of the data being sent back as a trailing header.
+This is an example demonstrating how you can process Response bodies in middleware using a type conforming to `ResponseBodyWriter`. The server has one endpoint `/echo` which will echo the body of the request back in its response. The response will also include in the response the SHA256 of the data being sent back as a trailing header.
 
 You can test the sample as follows:
 

--- a/upload/README.md
+++ b/upload/README.md
@@ -2,7 +2,7 @@
 
 Demonstrating file uploads to disk using Hummingbird.
 
-This demo may be useful for organziations that handle secret / sensitive data or otherwise do not want to rely on third party object storage vendors.
+This demo may be useful for organizations that handle secret / sensitive data or otherwise do not want to rely on third party object storage vendors.
 
 ## Crucial Requirements
 

--- a/webauthn/README.md
+++ b/webauthn/README.md
@@ -2,6 +2,6 @@
 
 WebAuthn is a standard for secure authentication on the web. It allows users to authenticate using a hardware token, such as a YubiKey, an iPhone or a biometric device, such as a fingerprint reader. This example demonstrates how to use the [webauthn-swift](https://github.com/swift-server/webauthn-swift) library to authenticate users using WebAuthn.
 
-Application demostrating authentication via WebAuthn passkeys. This example uses the webAuthn library https://github.com/swift-server/webauthn-swift. The sample also uses the result builder router from [HummingbirdRouter](https://docs.hummingbird.codes/2.0/documentation/hummingbirdrouter).
+Application demonstrating authentication via WebAuthn passkeys. This example uses the webAuthn library https://github.com/swift-server/webauthn-swift. The sample also uses the result builder router from [HummingbirdRouter](https://docs.hummingbird.codes/2.0/documentation/hummingbirdrouter).
 
 In your browser go to http://localhost:8080


### PR DESCRIPTION
There were a bunch of typos in the readme files.
All changes are backwards compatible.